### PR TITLE
do not fix pandas version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
-install_requires = ['boto3', 'pandas<0.25.0', 'gokart>=0.2.4', 'tqdm']
+install_requires = ['boto3', 'pandas', 'gokart>=0.2.4', 'tqdm']
 
 setup(
     name='thunderbolt',


### PR DESCRIPTION
I want to use thunderbolt on pandas 0.25.x (because I want to use `explode` method).
So, if there are no problem, please update `setup.py`