### PR TITLE
add get_data top_k

### DIFF
--- a/test/test_thunderbolt.py
+++ b/test/test_thunderbolt.py
@@ -84,6 +84,36 @@ class TestThunderbolt(unittest.TestCase):
             output = self.tb.get_data('task')
         self.assertEqual(output, target)
 
+    def test_get_data_top_k(self):
+        self.tb.tasks = {
+            'Task1': {
+                'task_name': 'task',
+                'last_modified': 'last_modified_1',
+                'task_params': 'task_params_1',
+                'task_hash': 'task_hash_1',
+                'task_log': 'task_log_1'
+            },
+            'Task2': {
+                'task_name': 'task',
+                'last_modified': 'last_modified_2',
+                'task_params': 'task_params_2',
+                'task_hash': 'task_hash_2',
+                'task_log': 'task_log_2'
+            },
+            'Task3': {
+                'task_name': 'task',
+                'last_modified': 'last_modified_3',
+                'task_params': 'task_params_3',
+                'task_hash': 'task_hash_3',
+                'task_log': 'task_log_3'
+            }
+        }
+        target = ['Task3', 'Task2']
+
+        with patch('thunderbolt.Thunderbolt.load', side_effect=lambda x: x):
+            output = self.tb.get_data('task', 2)
+        self.assertEqual(output, target)
+
     def test_load(self):
         self.tb.tasks = {
             'Task1': {

--- a/thunderbolt/thunderbolt.py
+++ b/thunderbolt/thunderbolt.py
@@ -57,18 +57,23 @@ class Thunderbolt:
             return df
         return df[['task_id', 'task_name', 'last_modified', 'task_params']]
 
-    def get_data(self, task_name: str) -> Union[list, Any]:
+    def get_data(self, task_name: str, top_k: int = 1) -> Union[list, Any]:
         """Load newest task output data.
 
         Args:
             task_name: gokart's task name.
+            top_k: top-k of newest output data.
 
         Returns:
             The return value is newest data or data list.
         """
         df = self.get_task_df()
         df = df.sort_values(by='last_modified', ascending=False)
-        return self.load(df.query(f'task_name=="{task_name}"')['task_id'].iloc[0])
+
+        data = [self.load(df.query(f'task_name=="{task_name}"')['task_id'].iloc[i]) for i in range(top_k)]
+        if len(data) == 1:
+            return data[0]
+        return data
 
     def load(self, task_id: int) -> Union[list, Any]:
         """Load File using gokart.load.


### PR DESCRIPTION
We can get multi task output.
```
X = tb.get_date('hoge', 2)
X
> ['hoge1', 'hoge2']
```
issue: https://github.com/m3dev/thunderbolt/issues