### PR TITLE
Update clients to return tasks sorted by last modified

### DIFF
--- a/test/test_thunderbolt.py
+++ b/test/test_thunderbolt.py
@@ -12,7 +12,7 @@ from thunderbolt.client.s3_client import S3Client
 class TestThunderbolt(unittest.TestCase):
     def setUp(self):
         def get_tasks():
-            pass
+            return []
 
         module_path = 'thunderbolt.client'
         with ExitStack() as stack:

--- a/test/test_thunderbolt.py
+++ b/test/test_thunderbolt.py
@@ -30,6 +30,43 @@ class TestThunderbolt(unittest.TestCase):
             output = self.tb._get_client(s, source_filters, source_tqdm_disable)
             self.assertEqual(type(output), t)
 
+    def test_get_tasks_dic(self):
+        tasks_list = [
+            {
+                'task_name': 'task',
+                'last_modified': 'last_modified_2',
+                'task_params': 'task_params_1',
+                'task_hash': 'task_hash_1',
+                'task_log': 'task_log_1'
+            },
+            {
+                'task_name': 'task',
+                'last_modified': 'last_modified_1',
+                'task_params': 'task_params_1',
+                'task_hash': 'task_hash_1',
+                'task_log': 'task_log_1'
+            }
+        ]
+        
+        target = {
+            0: {
+                'task_name': 'task',
+                'last_modified': 'last_modified_1',
+                'task_params': 'task_params_1',
+                'task_hash': 'task_hash_1',
+                'task_log': 'task_log_1'
+            },
+            1: {
+                'task_name': 'task',
+                'last_modified': 'last_modified_2',
+                'task_params': 'task_params_1',
+                'task_hash': 'task_hash_1',
+                'task_log': 'task_log_1'
+            }
+        }
+        output = self.tb._get_tasks_dic(tasks_list=tasks_list)
+        self.assertDictEqual(output, target)
+
     def test_get_task_df(self):
         self.tb.tasks = {
             'Task1': {

--- a/thunderbolt/client/gcs_client.py
+++ b/thunderbolt/client/gcs_client.py
@@ -15,7 +15,7 @@ class GCSClient:
         self.tqdm_disable = tqdm_disable
         self.gcs_client = GCSConfig().get_gcs_client()
 
-    def get_tasks(self) -> Dict[int, Dict[str, Any]]:
+    def get_tasks(self) -> List[Dict[str, Any]]:
         """Load all task_log from GCS"""
         files = self._get_gcs_objects()
         tasks_list = list()
@@ -32,8 +32,7 @@ class GCSClient:
                 'last_modified': datetime.strptime(meta['updated'].split('.')[0], '%Y-%m-%dT%H:%M:%S'),
                 'task_hash': n[-1].split('.')[0]
             })
-        tasks = {i: task for i, task in enumerate(sorted(tasks_list, key=lambda x: x['last_modified']))}
-        return tasks
+        return tasks_list
 
     def _get_gcs_objects(self) -> List[str]:
         """get GCS objects"""

--- a/thunderbolt/client/gcs_client.py
+++ b/thunderbolt/client/gcs_client.py
@@ -18,20 +18,21 @@ class GCSClient:
     def get_tasks(self) -> Dict[int, Dict[str, Any]]:
         """Load all task_log from GCS"""
         files = self._get_gcs_objects()
-        tasks = {}
-        for i, x in enumerate(tqdm(files, disable=self.tqdm_disable)):
+        tasks_list = list()
+        for x in tqdm(files, disable=self.tqdm_disable):
             n = x.split('/')[-1]
             if self.task_filters and not [f for f in self.task_filters if f in n]:
                 continue
             n = n.split('_')
             meta = self._get_gcs_object_info(x)
-            tasks[i] = {
+            tasks_list.append({
                 'task_name': '_'.join(n[:-1]),
                 'task_params': pickle.load(self.gcs_client.download(x.replace('task_log', 'task_params'))),
                 'task_log': pickle.load(self.gcs_client.download(x)),
                 'last_modified': datetime.strptime(meta['updated'].split('.')[0], '%Y-%m-%dT%H:%M:%S'),
                 'task_hash': n[-1].split('.')[0]
-            }
+            })
+        tasks = {i: task for i, task in enumerate(sorted(tasks_list, key=lambda x: x['last_modified']))}
         return tasks
 
     def _get_gcs_objects(self) -> List[str]:

--- a/thunderbolt/client/local_directory_client.py
+++ b/thunderbolt/client/local_directory_client.py
@@ -13,7 +13,7 @@ class LocalDirectoryClient:
         self.task_filters = task_filters
         self.tqdm_disable = tqdm_disable
 
-    def get_tasks(self) -> Dict[int, Dict[str, Any]]:
+    def get_tasks(self) -> List[Dict[str, Any]]:
         """Load all task_log from workspace_directory."""
         files = {str(path) for path in Path(os.path.join(self.workspace_directory, 'log/task_log')).rglob('*')}
         tasks_list = list()
@@ -34,8 +34,7 @@ class LocalDirectoryClient:
                 'last_modified': modified,
                 'task_hash': n[-1].split('.')[0],
             })
-        tasks = {i: task for i, task in enumerate(sorted(tasks_list, key=lambda x: x['last_modified']))}
-        return tasks
+        return tasks_list
 
     def to_absolute_path(self, x: str) -> str:
         """get file path"""

--- a/thunderbolt/client/local_directory_client.py
+++ b/thunderbolt/client/local_directory_client.py
@@ -16,8 +16,8 @@ class LocalDirectoryClient:
     def get_tasks(self) -> Dict[int, Dict[str, Any]]:
         """Load all task_log from workspace_directory."""
         files = {str(path) for path in Path(os.path.join(self.workspace_directory, 'log/task_log')).rglob('*')}
-        tasks = {}
-        for i, x in enumerate(tqdm(files, disable=self.tqdm_disable)):
+        tasks_list = list()
+        for x in tqdm(files, disable=self.tqdm_disable):
             n = x.split('/')[-1]
             if self.task_filters and not [x for x in self.task_filters if x in n]:
                 continue
@@ -27,13 +27,14 @@ class LocalDirectoryClient:
                 task_log = pickle.load(f)
             with open(x.replace('task_log', 'task_params'), 'rb') as f:
                 task_params = pickle.load(f)
-            tasks[i] = {
+            tasks_list.append({
                 'task_name': '_'.join(n[:-1]),
                 'task_params': task_params,
                 'task_log': task_log,
                 'last_modified': modified,
                 'task_hash': n[-1].split('.')[0],
-            }
+            })
+        tasks = {i: task for i, task in enumerate(sorted(tasks_list, key=lambda x: x['last_modified']))}
         return tasks
 
     def to_absolute_path(self, x: str) -> str:

--- a/thunderbolt/client/s3_client.py
+++ b/thunderbolt/client/s3_client.py
@@ -17,7 +17,7 @@ class S3Client:
         self.resource = boto3.resource('s3')
         self.s3client = Session().client('s3')
 
-    def get_tasks(self) -> Dict[int, Dict[str, Any]]:
+    def get_tasks(self) -> List[Dict[str, Any]]:
         """Load all task_log from S3"""
         files = self._get_s3_keys([], '')
         tasks_list = list()
@@ -33,8 +33,7 @@ class S3Client:
                 'last_modified': x['LastModified'],
                 'task_hash': n[-1].split('.')[0]
             })
-        tasks = {i: task for i, task in enumerate(sorted(tasks_list, key=lambda x: x['last_modified']))}
-        return tasks
+        return tasks_list
 
     def _get_s3_keys(self, keys: List[Dict[str, Any]] = [], marker: str = '') -> List[Dict[str, Any]]:
         """Recursively get Key from S3.

--- a/thunderbolt/client/s3_client.py
+++ b/thunderbolt/client/s3_client.py
@@ -20,19 +20,20 @@ class S3Client:
     def get_tasks(self) -> Dict[int, Dict[str, Any]]:
         """Load all task_log from S3"""
         files = self._get_s3_keys([], '')
-        tasks = {}
-        for i, x in enumerate(tqdm(files, disable=self.tqdm_disable)):
+        tasks_list = list()
+        for x in tqdm(files, disable=self.tqdm_disable):
             n = x['Key'].split('/')[-1]
             if self.task_filters and not [x for x in self.task_filters if x in n]:
                 continue
             n = n.split('_')
-            tasks[i] = {
+            tasks_list.append({
                 'task_name': '_'.join(n[:-1]),
                 'task_params': pickle.loads(self.resource.Object(self.bucket_name, x['Key'].replace('task_log', 'task_params')).get()['Body'].read()),
                 'task_log': pickle.loads(self.resource.Object(self.bucket_name, x['Key']).get()['Body'].read()),
                 'last_modified': x['LastModified'],
                 'task_hash': n[-1].split('.')[0]
-            }
+            })
+        tasks = {i: task for i, task in enumerate(sorted(tasks_list, key=lambda x: x['last_modified']))}
         return tasks
 
     def _get_s3_keys(self, keys: List[Dict[str, Any]] = [], marker: str = '') -> List[Dict[str, Any]]:

--- a/thunderbolt/thunderbolt.py
+++ b/thunderbolt/thunderbolt.py
@@ -37,8 +37,7 @@ class Thunderbolt:
         return LocalDirectoryClient(workspace_directory, filters, tqdm_disable)
 
     def _get_tasks_dic(self, tasks_list: List[Dict]) -> Dict[int, Dict]:
-        # return {i: task for i, task in enumerate(sorted(tasks_list, key=lambda x: x['last_modified']))}
-        return {i: task for i, task in enumerate(tasks_list)}
+        return {i: task for i, task in enumerate(sorted(tasks_list, key=lambda x: x['last_modified']))}
 
     def get_task_df(self, all_data: bool = False) -> pd.DataFrame:
         """Get task's pandas DataFrame.

--- a/thunderbolt/thunderbolt.py
+++ b/thunderbolt/thunderbolt.py
@@ -1,5 +1,5 @@
 import os
-from typing import Union, List, Any
+from typing import Union, List, Dict, Any
 import shutil
 
 import gokart
@@ -27,7 +27,7 @@ class Thunderbolt:
             env = os.getenv('TASK_WORKSPACE_DIRECTORY')
             workspace_directory = env if env else ''
         self.client = self._get_client(workspace_directory, [task_filters] if type(task_filters) == str else task_filters, not use_tqdm)
-        self.tasks = self.client.get_tasks()
+        self.tasks = self._get_tasks_dic(tasks_list=self.client.get_tasks())
 
     def _get_client(self, workspace_directory, filters, tqdm_disable):
         if workspace_directory.startswith('s3://'):
@@ -35,6 +35,10 @@ class Thunderbolt:
         elif workspace_directory.startswith('gs://') or workspace_directory.startswith('gcs://'):
             return GCSClient(workspace_directory, filters, tqdm_disable)
         return LocalDirectoryClient(workspace_directory, filters, tqdm_disable)
+
+    def _get_tasks_dic(self, tasks_list: List[Dict]) -> Dict[int, Dict]:
+        # return {i: task for i, task in enumerate(sorted(tasks_list, key=lambda x: x['last_modified']))}
+        return {i: task for i, task in enumerate(tasks_list)}
 
     def get_task_df(self, all_data: bool = False) -> pd.DataFrame:
         """Get task's pandas DataFrame.


### PR DESCRIPTION
## Summary
Currently, the `task_id` can be changed once new files are added.

In this PR, I propose to sort tasks by `last_modified`.

#### Before
<img width="644" alt="SS 2020-03-29 23 26 59" src="https://user-images.githubusercontent.com/17402261/77851624-20e54f00-7215-11ea-86af-64f9744e34e7.png">
As shown in the example notebook, tasks are not sorted by `last_modified`.
This can be a problem if one uses `tb.load` to get his/her DataFrame:
When you run tasks again, the old id does not point to what they used to and you have to look into ids to update them.

#### After
<img width="672" alt="SS 2020-03-29 23 27 09" src="https://user-images.githubusercontent.com/17402261/77851736-a406a500-7215-11ea-9583-d1a3cef8b8da.png">
Tasks are sorted by `last_modified`.
You can keep using the same id with `tb.load`.