### PR TITLE
Fix: S3Client.get_tasks

### DIFF
--- a/thunderbolt/client/s3_client.py
+++ b/thunderbolt/client/s3_client.py
@@ -34,7 +34,7 @@ class S3Client:
             n = n.split('_')
 
             if self.use_cache:
-                cache = self.local_cache.get(x['key'])
+                cache = self.local_cache.get(x['Key'])
                 if cache:
                     tasks_list.append(cache)
                     continue
@@ -49,7 +49,7 @@ class S3Client:
                 }
                 tasks_list.append(params)
                 if self.use_cache:
-                    self.local_cache.dump(x['key'], params)
+                    self.local_cache.dump(x['Key'], params)
             except Exception:
                 continue
 


### PR DESCRIPTION
In recent version(0.1.1), `S3Client.get_tasks()` doesn't work because the commit in https://github.com/m3dev/thunderbolt/pull/48 includes a minor mistake.

not `"key"`, but `"Key"` is correct for `x`'s key.
```py
            if self.use_cache:
                cache = self.local_cache.get(x['key'])
                if cache:
                    tasks_list.append(cache)
                    continue
```
This fix makes `get_tasks` work properly.

related issue: https://github.com/m3dev/thunderbolt/issues/47
